### PR TITLE
Made the file saving multi-OS friendly.

### DIFF
--- a/src/cash/utils/SaveHelper.java
+++ b/src/cash/utils/SaveHelper.java
@@ -21,10 +21,10 @@ public class SaveHelper {
 	public File getFile(String address,String dir){
 		System.out.println("BUT UHM");
 		try{
-		FileUtils.forceMkdir(new File(WORKING_DIR + '\\' + "downloads" + '\\' + dir));
+		FileUtils.forceMkdir(new File(WORKING_DIR + File.separator + dir));
 		int dot = address.lastIndexOf(".");
 		String extension = address.substring(dot+1);
-		return new File(WORKING_DIR + '\\' + "downloads" + '\\' + dir + '\\'+ getFileNumber(dir) + '.' + extension);
+		return new File(WORKING_DIR + File.separator + dir + File.separator+ getFileNumber(dir) + '.' + extension);
 		}catch(Exception e){
 			e.printStackTrace();
 			System.err.println("Error Getting File Location");


### PR DESCRIPTION
\ only works with windows based machines. File.separator means it'll get the unique separator value for the OS that is running the .jar. Eg: Unix (and unix based systems) use / not \
